### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/main/ @aNebula


### PR DESCRIPTION
Creating the CODEOWNERS file to assign Nebula (@aNebula) as the sole code owner for the main branch. This ensures that only Nebula can approve and merge pull requests into main, as per our protected branch policy.